### PR TITLE
Fix typos in IA portfolio posts

### DIFF
--- a/_posts/2023-10-14-Portfolio1IA.md
+++ b/_posts/2023-10-14-Portfolio1IA.md
@@ -5,7 +5,7 @@ categories: [studies,ai,portfolio1]
 tags: [ai,studies]
 ---
 
-# **Intruduction**
+# **Introduction**
 What is intelligence, and what is artificial intelligence? These are profound questions that we will explore from a particular perspective.
 
 To embark on this journey, it's crucial to first establish a foundation by delving into the historical context of intelligence, understanding its implications in various fields, including art, and dissecting both the advantages and potential risks associated with artificial intelligence. However, before we dive into these complex realms, we must grasp the fundamental definitions.

--- a/_posts/2023-10-30-Portfolio2IA.md
+++ b/_posts/2023-10-30-Portfolio2IA.md
@@ -5,7 +5,7 @@ categories: [studies,ai,portfolio2]
 tags: [ai,studies]
 ---
 
-# **Intruduction**
+# **Introduction**
 
 Welcome to a journey through the world of search algorithms! In this guide, we’ll explore various strategies that computers use to search and solve problems, making things work efficiently and intelligently.
 

--- a/_posts/2023-11-15-Portfolio4IA.md
+++ b/_posts/2023-11-15-Portfolio4IA.md
@@ -5,7 +5,7 @@ categories: [studies,ai,portfolio4]
 tags: [ai,studies]
 ---
 
-# **Intruduction**
+# **Introduction**
 Logical agents are a fascinating aspect of artificial intelligence, where machines make decisions based on logic and known information. To understand how they work, we delve into the realms of syntax and semantics in propositional logic.
 
 Syntax, in this context, is like the grammar of a language but for logical statements. It's about how we structure our logical sentences to organize our thoughts logically.

--- a/_posts/2023-11-6-Portfolio3IA.md
+++ b/_posts/2023-11-6-Portfolio3IA.md
@@ -5,7 +5,7 @@ categories: [studies,ai,portfolio3]
 tags: [ai,studies]
 ---
 
-# **Intruduction**
+# **Introduction**
 Constraint Satisfaction Problems (CSPs) are a foundational concept in computational theory and artificial intelligence, where the task is to find a combination of values that satisfies a set of constraints over given variables. In exploring CSPs, we encounter different strategies for representing the problem **atomic** representation treats each state as an indivisible unit, while **factored** representation breaks down states into a more granular view using variables or factors. The types of constraints **unary, binary, and n-ary** determine the interactions between these variables and play a crucial role in defining the complexity of the problem.
 
 To navigate through the potential solutions of a CSP, we rely on various levels of consistency checks, such as node consistency, arc consistency, and global consistency, each offering a measure to evaluate the feasibility of solutions. The choice of algorithm to resolve these problems can greatly impact the effectiveness and efficiency of the solution, with backtracking, forward checking, and constraint propagation (like AC-3) being among the most prevalent methods.
@@ -45,7 +45,7 @@ In the study of Constraint Satisfaction Problems (CSPs), there are several types
 
 In the context of Constraint Satisfaction Problems (CSPs), consistency is a key concept used to assess the solvability of the problem. It is evaluated at different levels:
 
-1. **Node Consistency**: Thi# **Intruduction**s level checks whether each individual variable in the CSP can satisfy its own constraints. Essentially, node consistency ensures that every value in a variable's domain meets the variable's unary constraints.
+1. **Node Consistency**: This level checks whether each individual variable in the CSP can satisfy its own constraints. Essentially, node consistency ensures that every value in a variable's domain meets the variable's unary constraints.
 
 2. **Arc Consistency**: This involves looking at each pair of variables and checking if there is some way to assign values to both such that their binary constraints are satisfied. For a CSP to be arc-consistent, every value in a variable's domain must be consistent with every possible value of each neighboring variable's domain.
 
@@ -73,7 +73,7 @@ We choose a variable as the root;​
 
 We order the tree so that each variable appears after its parent in the tree (topological classification);
 
-![Topological classidication](/imgs/Portfolio3_img_1.jpeg)_Topological classidication_
+![Topological classification](/imgs/Portfolio3_img_1.jpeg)_Topological classification_
 
 ### **Cutting conditioning**
 

--- a/_posts/2023-12-11-Portfolio5IA.md
+++ b/_posts/2023-12-11-Portfolio5IA.md
@@ -7,7 +7,7 @@ tags: [ai,studies]
 
 # **Quantifying uncertainties and Bayesian networks, Probabilistic reasoning over time and Kalman filters**
 
-# **Intruduction**
+# **Introduction**
 In the complex and dynamic world of data analysis and system modeling, understanding and managing uncertainty is a central challenge. Various methodologies and models have been developed to quantify and navigate these uncertainties, each suited to different scenarios and requirements. This introduction will briefly overview key concepts and tools widely used in this domain, focusing on their applications and underlying principles.
 
 We begin with **statistical inference**, a fundamental approach in statistics for making predictions or drawing conclusions about a population based on sample data. It encompasses descriptive and inductive inference, crucial for understanding data and making broader generalizations.

--- a/_posts/2023-12-17-Portfolio6IA.md
+++ b/_posts/2023-12-17-Portfolio6IA.md
@@ -5,7 +5,7 @@ categories: [studies,ai,portfolio6]
 tags: [ai,studies]
 ---
 
-# **Intruduction**
+# **Introduction**
 Machine Learning, a pivotal branch of artificial intelligence, has revolutionized the way we interact with technology and data. At its core, Machine Learning is about enabling machines to learn from data, identify patterns, and make decisions with minimal human intervention. This fascinating field blends computer science with statistics, offering innovative solutions to complex problems across various industries. From predictive analytics in business to advancements in healthcare diagnostics, Machine Learning's impact is profound and far-reaching.
 
 In this exploration of Machine Learning, we delve into its fundamental concepts, types, and algorithms. We'll discuss how machines use both supervised and unsupervised learning to make sense of vast datasets, the intricate dance of balancing overfitting and underfitting in model training, and the exciting realms of neural networks and deep learning, which mirror the workings of the human brain.


### PR DESCRIPTION
## Summary
- fix multiple `Introduction` headings typos across posts
- fix stray typo in portfolio 3 post about node consistency
- fix image alt text typo in portfolio 3 post

## Testing
- `bundle exec jekyll b`
- `bundle exec htmlproofer _site --disable-external=true --ignore-urls "/^http:\/\/127.0.0.1/,/^http:\/\/0.0.0.0/,/^http:\/\/localhost/"`


------
https://chatgpt.com/codex/tasks/task_e_6847a18ecba8832daa50cd3a3b8dd4bf